### PR TITLE
Support :Port as string

### DIFF
--- a/java/src/org/jruby/jubilee/RubyServer.java
+++ b/java/src/org/jruby/jubilee/RubyServer.java
@@ -66,7 +66,7 @@ public class RubyServer extends RubyObject {
         RubySymbol eventbus_prefix_k = runtime.newSymbol("eventbus_prefix");
 
         /* retrieve from passed in options */
-        this.port = RubyNumeric.num2int(options.op_aref(context, port_k));
+        this.port = RubyNumeric.num2int(options.op_aref(context, port_k).convertToInteger("to_i"));
         this.host = options.op_aref(context, host_k).asJavaString();
 
         this.ssl = options.op_aref(context, ssl_k).isTrue();

--- a/spec/integration/basic_rack_spec.rb
+++ b/spec/integration/basic_rack_spec.rb
@@ -86,4 +86,10 @@ feature "basic rack at non-root context" do
     end
   end
 
+  it "should handle the port being specified as a string" do
+    configurator = Jubilee::Configuration.new(:Port => '3333')
+    @server = Jubilee::Server.new(configurator.app, configurator.options)
+    @server.start
+    @server.stop
+  end
 end


### PR DESCRIPTION
This patch fixes an issue with running `rackup --port 3333`. For some reason `rackup` doesn't convert the argument to an int before passing it to the handler, and currently Jubilee's `RubyServer` expects this option to be numeric.

An example:

```
% cd spec/apps/rack/basic
% ruby -I ../../../../lib -S rackup -s jubilee --port 3333
TypeError: can't convert String into Integer
  initialize at org/jruby/jubilee/RubyServer.java:69
  initialize at /Users/theo/Documents/Code/jubilee/lib/jubilee/server.rb:9
         run at /Users/theo/Documents/Code/jubilee/lib/rack/handler/jubilee.rb:24
       start at /Users/theo/.rvm/gems/jruby-1.7.8@jubilee/gems/rack-1.5.2/lib/rack/server.rb:264
       start at /Users/theo/.rvm/gems/jruby-1.7.8@jubilee/gems/rack-1.5.2/lib/rack/server.rb:141
      (root) at /Users/theo/.rvm/gems/jruby-1.7.8@jubilee/gems/rack-1.5.2/bin/rackup:4
        load at org/jruby/RubyKernel.java:1103
      (root) at /Users/theo/.rvm/gems/jruby-1.7.8@jubilee/bin/rackup:23
```

But with this patch it starts nicely.

Thanks for Jubilee, I like it a lot. I hope I can help out along the way.
