### PR TITLE
Support string port (the other way)

### DIFF
--- a/lib/jubilee/server.rb
+++ b/lib/jubilee/server.rb
@@ -6,6 +6,7 @@ module Jubilee
       if (options[:ssl]) && options[:ssl_keystore].nil?
           raise ArgumentError, "Please provide a keystore for ssl"
       end
+      options[:Port] = options[:Port].to_i
       super(Application.new(app), options)
     end
   end

--- a/test/jubilee/test_server.rb
+++ b/test/jubilee/test_server.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'net/http'
+require 'open-uri'
 
 class TestJubileeServer < MiniTest::Unit::TestCase
   def setup
@@ -69,4 +70,11 @@ class TestJubileeServer < MiniTest::Unit::TestCase
     assert_equal "https", body
   end
 
+  def test_port_as_string
+    config = Jubilee::Configuration.new(rackup: File.join(File.dirname(__FILE__), "../config/config.ru"))
+    @server = Jubilee::Server.new(config.app, Port: @port.to_s)
+    @server.start
+    sleep 0.1
+    open("http://#{@host}:#{@port}/").read
+  end
 end


### PR DESCRIPTION
Here's the alternative version that you suggested, e.g. sanitizing the `:Port` option in `Jubilee::Server`. It doesn't hurt to keep the Java fix. I just thought I'd give you the option of choosing which method you prefer.

I realize it would have taken you 5s to make this fix yourself, so you don't have to merge this just because it's a PR.
